### PR TITLE
Welcome OpenStack gerrit by default!

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -33,6 +33,7 @@
         <item>TEAM Gummy</item>
         <item>SlimRoms</item>
         <item>Wikimedia</item>
+        <item>OpenStack</item>
     </string-array>
     <string-array name="gerrit_webaddresses" translatable="false">
         <item>http://gerrit.aicp-rom.com/</item>
@@ -50,6 +51,7 @@
         <item>http://review.gummyrom.com/</item>
         <item>https://gerrit.slimroms.net</item>
         <item>https://gerrit.wikimedia.org/r/</item>
+        <item>https://review.openstack.org/</item>
     </string-array>
     <string-array name="status_entries">
         <item>@string/reviewable</item>


### PR DESCRIPTION
OpenStack project has an extremely large gerrit instance and
developer base.  Adding the gerrit instance by default makes
this much more accessible.

Signed-off-by: Dave Walker (Daviey) email@daviey.com
